### PR TITLE
improving the performance in Windows

### DIFF
--- a/snmalloc-sys/build.rs
+++ b/snmalloc-sys/build.rs
@@ -12,6 +12,11 @@ fn main() {
     cfg = cfg.define("SNMALLOC_RUST_SUPPORT", "ON")
         .profile(build_type);
 
+    if cfg!(all(windows, target_env = "msvc")) {
+        cfg = cfg.define("CMAKE_CXX_FLAGS_RELEASE", "/MD /O2 /Ob2 /DNDEBUG");
+        cfg = cfg.define("CMAKE_C_FLAGS_RELEASE", "/MD /O2 /Ob2 /DNDEBUG");
+    }
+
     let target = if cfg!(feature = "1mib") {
         "snmallocshim-1mib-rust"
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ unsafe impl GlobalAlloc for SnMalloc {
     /// - `alignment` is less equal to `SUPERSLAB_SIZE` (defined in snmalloc)
     /// - Other constrains are the same as the rust standard library.
     /// The program may be forced to abort if the constrains are not full-filled.
+    #[inline(always)]
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         ffi::rust_alloc(layout.align(), layout.size()) as _
     }
@@ -49,6 +50,7 @@ unsafe impl GlobalAlloc for SnMalloc {
     /// - the memory is acquired using the same allocator and the pointer points to the start position.
     /// - Other constrains are the same as the rust standard library.
     /// The program may be forced to abort if the constrains are not full-filled.
+    #[inline(always)]
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         ffi::rust_dealloc(ptr as _, layout.align(), layout.size());
     }
@@ -62,6 +64,7 @@ unsafe impl GlobalAlloc for SnMalloc {
     /// - `alignment` fulfills all the requirements as `rust_alloc`
     /// - Other constrains are the same as the rust standard library.
     /// The program may be forced to abort if the constrains are not full-filled.
+    #[inline(always)]
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         ffi::rust_realloc(ptr as _, layout.align(), layout.size(), new_size) as _
     }


### PR DESCRIPTION
cmake-rs passes a default `CMAKE_CXX_FLAGS_RELEASE` which overrides cmake default ones. In consequence, it was getting rid of `/DNDEBUG` and leaving a lot of debug code in.
