### PR TITLE
Try to detect library search dirs for MinGW

### DIFF
--- a/snmalloc-sys/build.rs
+++ b/snmalloc-sys/build.rs
@@ -106,7 +106,7 @@ fn main() {
             });
 
         println!("cargo:rustc-link-lib=dylib=stdc++");
-        println!("cargo:rustc-link-lib=dylib=atomic-1");
+        println!("cargo:rustc-link-lib=dylib=atomic");
         println!("cargo:rustc-link-lib=dylib=winpthread");
         println!("cargo:rustc-link-lib=dylib=gcc_s");
     }


### PR DESCRIPTION
`gcc -print-search-dirs`  will show where gcc finds libraries, but this requires gcc.exe can be found in the PATH.

I think it is ugly to add all search dirs but this might be the simplest solution I can come up with now.
