### PR TITLE
add msvc flag /EHsc to fix warning C4530

### DIFF
--- a/snmalloc-sys/build.rs
+++ b/snmalloc-sys/build.rs
@@ -51,8 +51,8 @@ fn main() {
     }
 
     if cfg!(all(windows, target_env = "msvc")) {
-        cfg = cfg.define("CMAKE_CXX_FLAGS_RELEASE", "/MD /O2 /Ob2 /DNDEBUG");
-        cfg = cfg.define("CMAKE_C_FLAGS_RELEASE", "/MD /O2 /Ob2 /DNDEBUG");
+        cfg = cfg.define("CMAKE_CXX_FLAGS_RELEASE", "/MD /O2 /Ob2 /DNDEBUG /EHsc");
+        cfg = cfg.define("CMAKE_C_FLAGS_RELEASE", "/MD /O2 /Ob2 /DNDEBUG /EHsc");
     }
 
     if cfg!(all(windows, target_env = "gnu")) {


### PR DESCRIPTION
Fix MSVC build failure issue: https://github.com/SchrodingerZhu/snmalloc-rs/issues/73

Reference:  [Compiler Warning (level 1) C4530](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4530?view=vs-2017)  
