### PR TITLE
Addition of non-allocation tracking functions

### DIFF
--- a/snmalloc-sys/src/lib.rs
+++ b/snmalloc-sys/src/lib.rs
@@ -31,6 +31,36 @@ extern "C" {
     /// - `alignment` fulfills all the requirements as `rust_alloc`
     /// The program may be forced to abort if the constrains are not full-filled.
     pub fn rust_realloc(ptr: *mut c_void, alignment: size_t, old_size: size_t, new_size: size_t) -> *mut c_void;
+    
+    /// Allocate `count` items of `size` length each.
+    ///
+    /// Returns `null` if `count * size` overflows or on out-of-memory.
+    ///
+    /// All items are initialized to zero.
+    pub fn sn_calloc(count: usize, size: usize) -> *mut c_void;
+    
+    /// Allocate `size` bytes.
+    ///
+    /// Returns pointer to the allocated memory or null if out of memory.
+    /// Returns a unique pointer if called with `size` 0.
+    pub fn sn_malloc(size: usize) -> *mut c_void;
+
+    /// Re-allocate memory to `newsize` bytes.
+    ///
+    /// Return pointer to the allocated memory or null if out of memory. If null
+    /// is returned, the pointer `p` is not freed. Otherwise the original
+    /// pointer is either freed or returned as the reallocated result (in case
+    /// it fits in-place with the new size).
+    ///
+    /// If `p` is null, it behaves as [`mi_malloc`]. If `newsize` is larger than
+    /// the original `size` allocated for `p`, the bytes after `size` are
+    /// uninitialized.
+    pub fn sn_realloc(p: *mut c_void, newsize: usize) -> *mut c_void;
+
+    /// Free previously allocated memory.
+    ///
+    /// The pointer `p` must have been allocated before (or be null).
+    pub fn sn_free(p: *mut c_void);
 }
 
 #[cfg(test)]
@@ -43,7 +73,19 @@ mod tests {
         unsafe {*ptr = 127; assert_eq!(*ptr, 127)};
         unsafe { rust_dealloc(ptr as *mut c_void, 8, 8) };
     }
-
+    #[test]
+    fn it_frees_memory_sn_malloc() {
+        let ptr = unsafe { sn_malloc(8) } as *mut u8;
+        unsafe { sn_free(ptr as *mut c_void) };
+    }
+	
+    #[test]
+    fn it_frees_memory_sn_realloc() {
+        let ptr = unsafe { sn_malloc(8) } as *mut u8;
+        let ptr = unsafe { sn_realloc(ptr as *mut c_void, 8) } as *mut u8;
+        unsafe { sn_free(ptr as *mut c_void) };
+    }
+    
     #[test]
     fn it_reallocs_correctly() {
         let mut ptr = unsafe { rust_alloc(8, 8) } as *mut u8;


### PR DESCRIPTION
In order for lower overhead of allocation tracking for snmalloc in pyoxidizer (@indygreg) embedding python we would like to add access to snmalloc versions of malloc, free, realloc, and calloc. pull request has been merged to snmalloc for these additions [https://github.com/microsoft/snmalloc/pull/290](url) to rust.cc
