### PR TITLE
remove libc usage

### DIFF
--- a/snmalloc-sys/Cargo.toml
+++ b/snmalloc-sys/Cargo.toml
@@ -16,11 +16,6 @@ build = "build.rs"
 cc = {version = "1.0",optional=true}
 cmake = {version = "0.1",optional=true}
 
-
-[dependencies.libc]
-version = "0.2"
-default-features = false
-
 [features]
 default = ["1mib","build_cmake"]
 build_cc = ["cc"]

--- a/snmalloc-sys/build.rs
+++ b/snmalloc-sys/build.rs
@@ -33,7 +33,6 @@ fn main() {
     build.flag_if_supported("-g");
     build.flag_if_supported("-fomit-frame-pointer");
     build.flag_if_supported("-fpermissive");
-	build.flag_if_supported("-Wmaybe-uninitialized");
     build.static_crt(true);
     build.cpp(true);
     build.debug(false);

--- a/snmalloc-sys/build.rs
+++ b/snmalloc-sys/build.rs
@@ -33,6 +33,7 @@ fn main() {
     build.flag_if_supported("-g");
     build.flag_if_supported("-fomit-frame-pointer");
     build.flag_if_supported("-fpermissive");
+	build.flag_if_supported("-Wmaybe-uninitialized");
     build.static_crt(true);
     build.cpp(true);
     build.debug(false);

--- a/snmalloc-sys/src/lib.rs
+++ b/snmalloc-sys/src/lib.rs
@@ -1,8 +1,7 @@
 #![no_std]
 #![allow(non_camel_case_types)]
 
-use core::ffi::c_void;
-use libc::size_t;
+use {core::ffi::c_void, core::usize};
 
 extern "C" {
     /// Allocate the memory with the given alignment and size.
@@ -12,14 +11,14 @@ extern "C" {
     /// - `alignment` is greater than zero
     /// - `alignment` is a power of 2
     /// The program may be forced to abort if the constrains are not full-filled.
-    pub fn rust_alloc(alignment: size_t, size: size_t) -> *mut c_void;
+    pub fn rust_alloc(alignment: usize, size: usize) -> *mut c_void;
 
     /// De-allocate the memory at the given address with the given alignment and size.
     /// The client must assure the following things:
     /// - the memory is acquired using the same allocator and the pointer points to the start position.
     /// - `alignment` and `size` is the same as allocation
     /// The program may be forced to abort if the constrains are not full-filled.
-    pub fn rust_dealloc(ptr: *mut c_void, alignment: size_t, size: size_t) -> c_void;
+    pub fn rust_dealloc(ptr: *mut c_void, alignment: usize, size: usize) -> c_void;
 
     /// Re-allocate the memory at the given address with the given alignment and size.
     /// On success, it returns a pointer pointing to the required memory address.
@@ -32,9 +31,9 @@ extern "C" {
     /// The program may be forced to abort if the constrains are not full-filled.
     pub fn rust_realloc(
         ptr: *mut c_void,
-        alignment: size_t,
-        old_size: size_t,
-        new_size: size_t,
+        alignment: usize,
+        old_size: usize,
+        new_size: usize,
     ) -> *mut c_void;
 
     /// Allocate `count` items of `size` length each.


### PR DESCRIPTION
Not sure I see a reason to using libc::size_t instead of rust's usize which should be the same on rust platforms anyway. Saves 6 seconds on compilation and seems to reduce test time by .06 seconds because I believe libc is just overhead.

**Original:**
(base) D:\fork\snmalloc-rs>cargo test --workspace
    Updating crates.io index
   Compiling cc v1.0.67
   Compiling libc v0.2.93
   Compiling cmake v0.1.45
   Compiling snmalloc-sys v0.2.26 (D:\fork\snmalloc-rs\snmalloc-sys)
   Compiling snmalloc-rs v0.2.26 (D:\fork\snmalloc-rs)
    Finished test [unoptimized + debuginfo] target(s) in 29.75s
     Running target\debug\deps\snmalloc_rs-2847cd7b054242c4.exe

running 3 tests
test tests::it_frees_allocated_memory ... ok
test tests::it_frees_reallocated_memory ... ok
test tests::it_frees_zero_allocated_memory ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running target\debug\deps\snmalloc_sys-0a5a449d1bd6b08e.exe

running 5 tests
test tests::it_frees_memory_malloc ... ok
test tests::it_calculates_usable_size ... ok
test tests::it_frees_memory_sn_malloc ... ok
test tests::it_frees_memory_sn_realloc ... ok
test tests::it_reallocs_correctly ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests snmalloc-sys

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests snmalloc-rs

running 1 test
test src\lib.rs - (line 24) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.57s

**New without libc:**
(base) D:\fork\snmalloc-rs>cargo test --workspace
   Compiling cc v1.0.67
   Compiling cmake v0.1.45
   Compiling snmalloc-sys v0.2.26 (D:\fork\snmalloc-rs\snmalloc-sys)
   Compiling snmalloc-rs v0.2.26 (D:\fork\snmalloc-rs)
    Finished test [unoptimized + debuginfo] target(s) in 23.36s
     Running target\debug\deps\snmalloc_rs-cafe9d9e8c56b241.exe

running 3 tests
test tests::it_frees_allocated_memory ... ok
test tests::it_frees_zero_allocated_memory ... ok
test tests::it_frees_reallocated_memory ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running target\debug\deps\snmalloc_sys-52e4284250df16ff.exe

running 5 tests
test tests::it_calculates_usable_size ... ok
test tests::it_frees_memory_malloc ... ok
test tests::it_frees_memory_sn_malloc ... ok
test tests::it_frees_memory_sn_realloc ... ok
test tests::it_reallocs_correctly ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests snmalloc-sys

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests snmalloc-rs

running 1 test
test src\lib.rs - (line 24) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s
