### PR TITLE
Updates for 0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 0.3.1 
+- Fixes `build_cc` feature (broken in 0.3.0 release).
+- Fixes `native-cpu` feature (broken in 0.3.0 release).
+
 ### 0.3.0 
 - Release to follow upstream 0.6.0
 - **upstream** Major redesign of the code to improve performance and 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snmalloc-rs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["schrodingerzhu <i@zhuyi.fan>"]
 edition = "2021"
 license = "MIT"
@@ -16,7 +16,7 @@ readme = "README.md"
 members = ["snmalloc-sys" ]
 
 [dependencies]
-snmalloc-sys = {version = "0.3.0", path = "snmalloc-sys", default-features = false }
+snmalloc-sys = {version = "0.3.1", path = "snmalloc-sys", default-features = false }
 
 [features]
 default = ["snmalloc-sys/build_cmake"]

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ target.
 
 ## Changelog
 
+### 0.3.1 
+
+- Fixes `build_cc` feature (broken in 0.3.0 release).
+- Fixes `native-cpu` feature (broken in 0.3.0 release).
+
 ### 0.3.0
 
 - Release to support snmalloc 0.6.0.
@@ -91,14 +96,5 @@ target.
 - Deprecation of `cache-friendly`
 - Use exposed `alloc_zeroed` from `snmalloc`
 - **upstream** changes of remote communication, corruption detection and compilation flag detection.
-
-### 0.2.27
-
-- Reduction of libc dependency
-- **upstream** Windows 7 and windows 8 compatibility added
-- **upstream** Option to use C++20 standards if available
-- **upstream** Preparations of cherification (heavy refactors of the structure)
-- **upstream** Cold routine annotations
-
 
 for older versions, see [CHANGELOG](CHANGELOG.md) 

--- a/snmalloc-sys/Cargo.toml
+++ b/snmalloc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snmalloc-sys"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["schrodingerzhu <i@zhuyi.fan>"]
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Contains the fixes to `native-cpu` and `build_cc`, which were both broken in the `0.3.1` release.