### PR TITLE
github action for macOs is going to remove 12 release support.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-11, macos-14, ubuntu-latest]
+        os: [windows-latest, macos-13, macos-14, ubuntu-latest]
         rust: [stable, nightly]
     steps:
     - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
ref: https://github.com/actions/runner-images/issues/10721